### PR TITLE
Missing space after argument type

### DIFF
--- a/node_translators/helper/arguments.js
+++ b/node_translators/helper/arguments.js
@@ -7,7 +7,7 @@ function processElement(indent, ws, codegen) {
     var str = '';
 
     if (arg.type) { // type hint
-      str += codegen(arg.type, indent);
+      str += codegen(arg.type, indent) + ' ';
     }
 
     if (arg.byref) { // byref


### PR DESCRIPTION
The arguments weren't correctly generated, the space was missing between the type and the variable name.